### PR TITLE
Build linux version with fontmgr_custom flag.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -295,7 +295,7 @@ optional("fontmgr_android") {
 }
 
 optional("fontmgr_custom") {
-  enabled = skia_enable_fontmgr_custom
+  enabled = skia_enable_fontmgr_custom || is_linux
 
   deps = [ ":typeface_freetype" ]
   sources = [


### PR DESCRIPTION
linux version 没有 build 
```
sk_sp<SkFontMgr> SkFontMgr_New_Custom_Data(const uint8_t** datas, const size_t* sizes, int n, bool copy) {
```

导致 link 出错